### PR TITLE
Reworked the way progession tracking is handled when adding a new pro…

### DIFF
--- a/OSRS-COMPANION/src/main/java/com/example/OSRSCOMPANION/models/Player.java
+++ b/OSRS-COMPANION/src/main/java/com/example/OSRSCOMPANION/models/Player.java
@@ -240,7 +240,10 @@ public class Player {
 
         Timestamp earliestDate = new Timestamp(System.currentTimeMillis()-(days * day));
 
-       setProgressionNotRecent();
+        if(normalProgression.size() > 0){
+            setProgressionNotRecent();
+        }
+
 
         if (this.normalData.size() > 2) {
             pointsInTimeRange = findPointsInTimeRange(this.normalData, earliestDate);
@@ -281,23 +284,27 @@ public class Player {
 
     public void addProgressionDataPoint(DataPoint oldestDataPoint,DataPoint currentDataPoint,String hiscoreType){
 
+
+        ProgressionDataPoint newDataPoint = new ProgressionDataPoint();
+
+
         for(skillNames skill :skillNames.values()){
             skillData newSkillDataPoint = currentDataPoint.getSkillInfo().get(skill.getSkillNumber());
             skillData oldSkillDataPoint = oldestDataPoint.getSkillInfo().get(skill.getSkillNumber());
-
             long rankDifference = newSkillDataPoint.getRank() - oldSkillDataPoint.getRank();
             long experienceDifference = newSkillDataPoint.getExperience() - oldSkillDataPoint.getExperience();
             long levelDifference = newSkillDataPoint.getLevel() - oldSkillDataPoint.getLevel();
-            if(hiscoreType.equals("normal")){
-                this.normalProgression.add(new ProgressionDataPoint(new skillProgressionData(rankDifference,experienceDifference,levelDifference,skill.getSkillName()),true,false,false,false));
-            }else if(hiscoreType.equals("ironman")){
-                this.ironmanProgression.add(new ProgressionDataPoint(new skillProgressionData(rankDifference,experienceDifference,levelDifference,skill.getSkillName()),false,true,false,false));
-            }else if(hiscoreType.equals("ultimate")){
-                this.ultimateProgression.add(new ProgressionDataPoint(new skillProgressionData(rankDifference,experienceDifference,levelDifference,skill.getSkillName()),false,false,false,true));
-            }else if(hiscoreType.equals("hardcore")){
-                this.hardcoreProgression.add(new ProgressionDataPoint(new skillProgressionData(rankDifference,experienceDifference,levelDifference,skill.getSkillName()),false,false,true,false));
-            }
+            newDataPoint.addSkillProgressionData(new skillProgressionData(rankDifference,experienceDifference,levelDifference,skill.getSkillName()));
+        }
 
+        if(hiscoreType.equals("normal")){
+            this.normalProgression.add(newDataPoint);
+        }else if(hiscoreType.equals("ironman")){
+            this.ironmanProgression.add(newDataPoint);
+        }else if(hiscoreType.equals("ultimate")){
+            this.ultimateProgression.add(newDataPoint);
+        }else if(hiscoreType.equals("hardcore")){
+            this.hardcoreProgression.add(newDataPoint);
         }
 
     }

--- a/OSRS-COMPANION/src/main/java/com/example/OSRSCOMPANION/models/ProgressionTracking/ProgressionDataPoint.java
+++ b/OSRS-COMPANION/src/main/java/com/example/OSRSCOMPANION/models/ProgressionTracking/ProgressionDataPoint.java
@@ -40,6 +40,10 @@ public class ProgressionDataPoint {
 
     //|||METHODS|||
 
+    public void addSkillProgressionData(skillProgressionData skillProgressionData){
+        this.progressionData.add(skillProgressionData);
+    }
+
     //|||ACCESSORS|||
 
     public int getId() {


### PR DESCRIPTION
…gression object. it should now add 1 progression object with 24 skillprogression objects inside of the array. New bugs found within the home controller when attempted to search with an empty database. I think the frontend is expecting a progressiondata object but when a new player is searched none are made. So I will need to add a default amount of progression to check for when a player is searched for. Probably 1 day of progression by default.